### PR TITLE
Container CPU percent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem 'fluent-logger', '~> 0.7.2'
 
 gem 'net_http_unix', '~> 0.2.2'
 
+gem 'mini_cache', '~> 1.1.0'
+

--- a/docker-monitor-fluent.rb
+++ b/docker-monitor-fluent.rb
@@ -58,9 +58,9 @@ loop do
     end
 
     # For ease of downstream processing, we can do some calculations here and add them in to the stats object
-    if  stats.dig('memory_stats', 'usage') && 
-        stats.dig('memory_stats', 'max_usage') && 
-        stats.dig('memory_stats', 'limit') && 
+    if  stats.dig('memory_stats', 'usage') &&
+        stats.dig('memory_stats', 'max_usage') &&
+        stats.dig('memory_stats', 'limit') &&
         stats.dig('memory_stats','stats','cache')
 
       # As we are doing integer maths, the 100* needs to go before the division


### PR DESCRIPTION
Support calculation of per container CPU percent:

 * ... available in `stats.cpu_stats._cpu_usage_percent` field
 * This is the percent of one CPU, so on multiple CPU machines, this can exceed 100%
 * This is the average CPU usage consumed over `WAIT_TIME` seconds

