### PR TITLE
Support injecting an instance identifier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     mem_limit: 48m
     cpus: '0.2'
     environment:
+      SID: 'my special identifier'
       DEBUG: 'false'
       FLUENTD_HOST: 'fluentd-test'
       FLUENTD_PORT: '24224'

--- a/docker-monitor-fluent.rb
+++ b/docker-monitor-fluent.rb
@@ -13,6 +13,7 @@ WAIT_TIME =       ENV['WAIT_TIME'].to_i      || 60
 DOCKER_SOCKET =   ENV['DOCKER_SOCKET']       || 'unix:///var/run/docker.sock'
 DEBUG =           (ENV['DEBUG'] == 'true')   ? true : false
 INSPECT_STATE =   (ENV['INSPECT_STATE'] == 'false')   ? false: true
+SID =             ENV['SID']                 || nil
 
 puts '== Docker Monitor Fluentd'
 puts DateTime.now
@@ -120,6 +121,8 @@ loop do
       stats: stats
     }.merge(
       INSPECT_STATE ? { inspect_state: inspect_state.dig('State') } : { }
+    ).merge(
+      SID.nil? ? { } : { sid: SID }
     ))
       $stderr.puts fluent.last_error
       sleep 10


### PR DESCRIPTION
Support injecting an instance identifier in to the messages sent to fluentd

The value of environment variable `SID`, if set, will be placed in to field `sid` in the message.